### PR TITLE
Add "sha1" Argument to upload file args.

### DIFF
--- a/lib/actions/file.js
+++ b/lib/actions/file.js
@@ -13,6 +13,7 @@ exports.uploadFile = function(b2, args) {
     var data = args.data;
     var info = args.info;
     var mime = args.mime;
+    var dataSha1 = args.sha1;
 
     var options = {
         url: uploadUrl,
@@ -21,10 +22,15 @@ exports.uploadFile = function(b2, args) {
             Authorization: uploadAuthToken,
             'Content-Type': mime || 'b2/x-auto',
             'X-Bz-File-Name': filename,
-            'X-Bz-Content-Sha1': data ? sha1(data) : null
+            'X-Bz-Content-Sha1': dataSha1
         },
         body: data
     };
+    
+    if(!options.headers['X-Bz-Content-Sha1']) {
+        options.headers['X-Bz-Content-Sha1'] = data ? sha1(data) : null;
+    }
+    
     headersUtil.addInfoHeaders(options, info);
     return request.sendRequest(options);
 };


### PR DESCRIPTION
Defaults 'X-Bz-Content-Sha1' to the 'sha1' argument. If this value is not set the functionality will roll back to using the data or sha1 of the data which is passed in. Effectively this allows callers who have already calculated their SHA1 to send it to this function and not re-calculate it. Prevents the unnecessary calculation from happening again.